### PR TITLE
Add audio/MIDI settings popup with ~ key shortcut

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ target_sources(Vitracker PRIVATE
     src/ui/SamplerScreen.cpp
     src/ui/HelpPopup.cpp
     src/ui/ChordPopup.cpp
+    src/ui/AudioSettingsPopup.cpp
     src/audio/Voice.cpp
     src/audio/AudioEngine.cpp
     src/audio/Effects.cpp

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -98,6 +98,10 @@ App::App()
     // Initialize help popup (hidden by default, always on top)
     addChildComponent(helpPopup_);
 
+    // Initialize audio settings popup (hidden by default)
+    audioSettingsPopup_ = std::make_unique<ui::AudioSettingsPopup>(deviceManager_);
+    addChildComponent(audioSettingsPopup_.get());
+
     // Initialize Tip Me button (mouse-only, no keyboard focus)
     tipMeButton_.setColour(juce::TextButton::buttonColourId, juce::Colour(0xffff5e5b));
     tipMeButton_.setColour(juce::TextButton::textColourOffId, juce::Colours::white);
@@ -543,6 +547,10 @@ void App::resized()
     // Help popup covers the whole window
     helpPopup_.setBounds(getLocalBounds());
 
+    // Audio settings popup covers the whole window (centered dialog inside)
+    if (audioSettingsPopup_)
+        audioSettingsPopup_->setBounds(getLocalBounds());
+
     // Position Tip Me button in status bar (right side)
     tipMeButton_.setBounds(statusBarArea.removeFromRight(70).reduced(4, 3));
 }
@@ -566,6 +574,25 @@ void App::visibilityChanged()
 bool App::keyPressed(const juce::KeyPress& key, juce::Component* originatingComponent)
 {
     juce::ignoreUnused(originatingComponent);
+
+    // Handle audio settings popup toggle (~)
+    if (key.getTextCharacter() == '~' || key.getTextCharacter() == '`')
+    {
+        toggleAudioSettings();
+        return true;
+    }
+
+    // If audio settings is showing, Escape or ~ closes it
+    if (audioSettingsPopup_ && audioSettingsPopup_->isShowing())
+    {
+        if (key.getKeyCode() == juce::KeyPress::escapeKey)
+        {
+            hideAudioSettings();
+            return true;
+        }
+        // Allow typing in the settings dialog - don't block all keys
+        return false;
+    }
 
     // Handle help popup toggle
     if (key.getTextCharacter() == '?')
@@ -801,6 +828,33 @@ void App::toggleHelp()
         hideHelp();
     else
         showHelp();
+}
+
+// Audio settings popup
+void App::showAudioSettings()
+{
+    if (audioSettingsPopup_)
+    {
+        audioSettingsPopup_->show();
+        audioSettingsPopup_->toFront(true);
+    }
+}
+
+void App::hideAudioSettings()
+{
+    if (audioSettingsPopup_)
+        audioSettingsPopup_->hide();
+}
+
+void App::toggleAudioSettings()
+{
+    if (audioSettingsPopup_)
+    {
+        if (audioSettingsPopup_->isShowing())
+            hideAudioSettings();
+        else
+            showAudioSettings();
+    }
 }
 
 // Tempo adjust mode

--- a/src/App.h
+++ b/src/App.h
@@ -8,6 +8,7 @@
 #include "audio/AudioEngine.h"
 #include "ui/Screen.h"
 #include "ui/HelpPopup.h"
+#include "ui/AudioSettingsPopup.h"
 #include <memory>
 #include <array>
 #include <functional>
@@ -79,6 +80,12 @@ private:
     void showHelp();
     void hideHelp();
     void toggleHelp();
+
+    // Audio settings popup
+    std::unique_ptr<ui::AudioSettingsPopup> audioSettingsPopup_;
+    void showAudioSettings();
+    void hideAudioSettings();
+    void toggleAudioSettings();
 
     // Tip Me button
     juce::TextButton tipMeButton_{"Tip Me"};

--- a/src/ui/AudioSettingsPopup.cpp
+++ b/src/ui/AudioSettingsPopup.cpp
@@ -1,0 +1,87 @@
+#include "AudioSettingsPopup.h"
+
+namespace ui {
+
+AudioSettingsPopup::AudioSettingsPopup(juce::AudioDeviceManager& deviceManager)
+    : selector_(deviceManager,
+                0,      // minAudioInputChannels
+                2,      // maxAudioInputChannels
+                0,      // minAudioOutputChannels
+                2,      // maxAudioOutputChannels
+                true,   // showMidiInputOptions
+                true,   // showMidiOutputSelector
+                false,  // showChannelsAsStereoPairs
+                false)  // hideAdvancedOptionsWithButton
+{
+    addAndMakeVisible(selector_);
+    setVisible(false);
+}
+
+void AudioSettingsPopup::paint(juce::Graphics& g)
+{
+    // Draw semi-transparent background overlay
+    g.fillAll(juce::Colour(0x80000000));
+
+    // Calculate panel bounds
+    auto bounds = getLocalBounds();
+    int panelWidth = kWidth + kPadding * 2;
+    int panelHeight = kHeight + kPadding * 2 + kTitleHeight;
+    auto panelBounds = bounds.withSizeKeepingCentre(panelWidth, panelHeight);
+
+    // Draw panel background
+    g.setColour(panelColor);
+    g.fillRoundedRectangle(panelBounds.toFloat(), 8.0f);
+
+    // Draw panel border
+    g.setColour(borderColor);
+    g.drawRoundedRectangle(panelBounds.toFloat(), 8.0f, 2.0f);
+
+    // Draw title
+    g.setColour(titleColor);
+    g.setFont(juce::Font(18.0f).boldened());
+    auto titleBounds = panelBounds.removeFromTop(kTitleHeight + kPadding);
+    g.drawText("Audio/MIDI Settings", titleBounds.reduced(kPadding, 0),
+               juce::Justification::centredLeft);
+
+    // Draw hint at the bottom
+    g.setColour(juce::Colour(0xff888888));
+    g.setFont(juce::Font(12.0f));
+    g.drawText("Press ~ or Escape to close",
+               panelBounds.removeFromBottom(20).reduced(kPadding, 0),
+               juce::Justification::centredRight);
+}
+
+void AudioSettingsPopup::resized()
+{
+    auto bounds = getLocalBounds();
+    int panelWidth = kWidth + kPadding * 2;
+    int panelHeight = kHeight + kPadding * 2 + kTitleHeight;
+    auto panelBounds = bounds.withSizeKeepingCentre(panelWidth, panelHeight);
+
+    // Position selector inside panel (below title, above hint)
+    auto selectorBounds = panelBounds.reduced(kPadding);
+    selectorBounds.removeFromTop(kTitleHeight);
+    selectorBounds.removeFromBottom(20);  // Space for hint text
+    selector_.setBounds(selectorBounds);
+}
+
+void AudioSettingsPopup::show()
+{
+    setVisible(true);
+    toFront(true);
+}
+
+void AudioSettingsPopup::hide()
+{
+    setVisible(false);
+}
+
+void AudioSettingsPopup::toggle()
+{
+    if (isVisible())
+        hide();
+    else
+        show();
+}
+
+} // namespace ui

--- a/src/ui/AudioSettingsPopup.h
+++ b/src/ui/AudioSettingsPopup.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <JuceHeader.h>
+
+namespace ui {
+
+class AudioSettingsPopup : public juce::Component
+{
+public:
+    AudioSettingsPopup(juce::AudioDeviceManager& deviceManager);
+    ~AudioSettingsPopup() override = default;
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+    bool isShowing() const { return isVisible(); }
+    void show();
+    void hide();
+    void toggle();
+
+private:
+    juce::AudioDeviceSelectorComponent selector_;
+
+    // Layout constants
+    static constexpr int kWidth = 500;
+    static constexpr int kHeight = 400;
+    static constexpr int kPadding = 20;
+    static constexpr int kTitleHeight = 30;
+
+    // Colors (matching app theme)
+    static inline const juce::Colour bgColor{0xff1a1a2e};
+    static inline const juce::Colour panelColor{0xff2a2a4e};
+    static inline const juce::Colour borderColor{0xff4a4a6e};
+    static inline const juce::Colour titleColor{0xff7c7cff};
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioSettingsPopup)
+};
+
+} // namespace ui


### PR DESCRIPTION
## Summary
- Added global audio/MIDI settings popup accessible via `~` key
- Wraps JUCE's `AudioDeviceSelectorComponent` for device configuration
- Allows users to configure audio output device, sample rate, buffer size, and MIDI I/O

## Changes
- Created `AudioSettingsPopup` component in `src/ui/`
- Added `~` key handler in `App::keyPressed()` to toggle popup
- Popup can be closed with `~` or `Escape` key
- Styled to match app's dark theme with centered dialog panel

## Test Plan
- [x] Build succeeds
- [x] Launch app and press `~` to open settings
- [x] Verify audio device selector shows available devices
- [x] Verify MIDI input/output options are displayed
- [x] Test closing with `Escape` and `~` keys
- [ ] Manual testing: Change audio device and verify it works
- [ ] Manual testing: Enable MIDI input and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)